### PR TITLE
Tvk/fix duplicated sha256 definition

### DIFF
--- a/src/backend/ref/hash-sha256.c
+++ b/src/backend/ref/hash-sha256.c
@@ -39,7 +39,7 @@ static void noise_sha256_reset(NoiseHashState *state)
 static void noise_sha256_update(NoiseHashState *state, const uint8_t *data, size_t len)
 {
     NoiseSHA256State *st = (NoiseSHA256State *)state;
-    sha256_update(&(st->sha256), data, len);
+    sha2_sha256_update(&(st->sha256), data, len);
 }
 
 static void noise_sha256_finalize(NoiseHashState *state, uint8_t *hash)

--- a/src/crypto/sha2/sha256.c
+++ b/src/crypto/sha2/sha256.c
@@ -126,7 +126,7 @@ static void sha256_transform(sha256_context_t *context, const uint8_t *m)
     context->h[7] += h;
 }
 
-void sha256_update(sha256_context_t *context, const void *data, size_t size)
+void sha2_sha256_update(sha256_context_t *context, const void *data, size_t size)
 {
     const uint8_t *d = (const uint8_t *)data;
     while (size > 0) {

--- a/src/crypto/sha2/sha256.h
+++ b/src/crypto/sha2/sha256.h
@@ -40,7 +40,7 @@ typedef struct
 } sha256_context_t;
 
 void sha256_reset(sha256_context_t *context);
-void sha256_update(sha256_context_t *context, const void *data, size_t size);
+void sha2_sha256_update(sha256_context_t *context, const void *data, size_t size);
 void sha256_finish(sha256_context_t *context, uint8_t *hash);
 
 #ifdef __cplusplus

--- a/src/protocol/util.c
+++ b/src/protocol/util.c
@@ -26,7 +26,7 @@
 #include <sodium.h>
 typedef crypto_hash_sha256_state sha256_context_t;
 #define sha256_reset(ctx) crypto_hash_sha256_init(ctx)
-#define sha256_update(ctx, pub, pub_len) crypto_hash_sha256_update(ctx, pub, pub_len)
+#define sha2_sha256_update(ctx, pub, pub_len) crypto_hash_sha256_update(ctx, pub, pub_len)
 #define sha256_finish(ctx, hash) crypto_hash_sha256_final(ctx, hash)
 #else
 #include "crypto/sha2/sha256.h"
@@ -275,7 +275,7 @@ int noise_format_fingerprint
 
     /* Hash the public key with SHA256 */
     sha256_reset(&sha256);
-    sha256_update(&sha256, public_key, public_key_len);
+    sha2_sha256_update(&sha256, public_key, public_key_len);
     sha256_finish(&sha256, hash);
     noise_clean(&sha256, sizeof(sha256));
 


### PR DESCRIPTION
+ changed the name of the function sha256_update() to avoid conflict with other modules in Spresense
+ add support mbedtls in noise_rand_bytes() 